### PR TITLE
use default .gz compression not .xz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,12 @@ deb: build strip
 
 	mkdir -p _workarea/etc/systemd/system
 	cp packaging/systemd/ncr.service _workarea/etc/systemd/system
-	fpm -f -t deb -s dir -C _workarea --name "$(NAME)" --version "$(VERSION)" --architecture "$(ARCH)" --maintainer "$(MAINTAINER)" --description "$(DESCRIPTION)" --url "$(URL)" --config-files /etc --deb-compression xz --deb-suggests nagios-plugins --deb-no-default-config-files --after-install packaging/after-install.sh --after-upgrade packaging/after-upgrade.sh --before-remove packaging/before-remove.sh .
+	fpm -f -t deb -s dir -C _workarea --name "$(NAME)" --version "$(VERSION)" --architecture "$(ARCH)" --maintainer "$(MAINTAINER)" --description "$(DESCRIPTION)" --url "$(URL)" --config-files /etc --deb-suggests nagios-plugins --deb-no-default-config-files --after-install packaging/after-install.sh --after-upgrade packaging/after-upgrade.sh --before-remove packaging/before-remove.sh .
 
 	rm -rf _workarea/etc/systemd/
 	mkdir -p _workarea/etc/init
 	cp packaging/upstart/ncr.conf _workarea/etc/init
-	fpm -f -t deb -s dir -C _workarea --name "$(NAME)-upstart" --version "$(VERSION)" --architecture "$(ARCH)" --maintainer "$(MAINTAINER)" --description "$(DESCRIPTION)" --url "$(URL)" --config-files /etc --deb-compression xz --deb-suggests nagios-plugins --deb-no-default-config-files --after-install packaging/after-install.sh --after-upgrade packaging/after-upgrade.sh --before-remove packaging/before-remove.sh .
+	fpm -f -t deb -s dir -C _workarea --name "$(NAME)-upstart" --version "$(VERSION)" --architecture "$(ARCH)" --maintainer "$(MAINTAINER)" --description "$(DESCRIPTION)" --url "$(URL)" --config-files /etc --deb-suggests nagios-plugins --deb-no-default-config-files --after-install packaging/after-install.sh --after-upgrade packaging/after-upgrade.sh --before-remove packaging/before-remove.sh .
 
 arm6_deb:
 	GOARCH=arm GOARM=6 go build -ldflags "-X main.version=$(VERSION)" cmd/*.go
@@ -45,9 +45,9 @@ arm6_deb:
 
 	mkdir -p _workarea/etc/systemd/system
 	cp packaging/systemd/ncr.service _workarea/etc/systemd/system
-	fpm -f -t deb -s dir -C _workarea --name "$(NAME)" --version "$(VERSION)" --architecture armhf --maintainer "$(MAINTAINER)" --description "$(DESCRIPTION)" --url "$(URL)" --config-files /etc --deb-compression xz --deb-suggests nagios-plugins --deb-no-default-config-files --after-install packaging/after-install.sh --after-upgrade packaging/after-upgrade.sh --before-remove packaging/before-remove.sh .
+	fpm -f -t deb -s dir -C _workarea --name "$(NAME)" --version "$(VERSION)" --architecture armhf --maintainer "$(MAINTAINER)" --description "$(DESCRIPTION)" --url "$(URL)" --config-files /etc --deb-suggests nagios-plugins --deb-no-default-config-files --after-install packaging/after-install.sh --after-upgrade packaging/after-upgrade.sh --before-remove packaging/before-remove.sh .
 
 	rm -rf _workarea/etc/systemd/
 	mkdir -p _workarea/etc/init
 	cp packaging/upstart/ncr.conf _workarea/etc/init
-	fpm -f -t deb -s dir -C _workarea --name "$(NAME)-upstart" --version "$(VERSION)" --architecture armhf --maintainer "$(MAINTAINER)" --description "$(DESCRIPTION)" --url "$(URL)" --config-files /etc --deb-compression xz --deb-suggests nagios-plugins --deb-no-default-config-files --after-install packaging/after-install.sh --after-upgrade packaging/after-upgrade.sh --before-remove packaging/before-remove.sh .
+	fpm -f -t deb -s dir -C _workarea --name "$(NAME)-upstart" --version "$(VERSION)" --architecture armhf --maintainer "$(MAINTAINER)" --description "$(DESCRIPTION)" --url "$(URL)" --config-files /etc --deb-suggests nagios-plugins --deb-no-default-config-files --after-install packaging/after-install.sh --after-upgrade packaging/after-upgrade.sh --before-remove packaging/before-remove.sh .


### PR DESCRIPTION
dpkg-scanpackages doesn't seem to like .xz:
```
fatal: [83.217.93.224]: FAILED! => {"changed": true, "cmd": "dpkg-scanpackages . > Packages", "delta": "0:00:00.083082", "end": "2020-03-20 13:10:43.326796", "msg": "non-zero return code", "rc": 25, "start": "2020-03-20 13:10:43.243714", "stderr": "tar: Archive is compressed. Use -J option\ntar: Error is not recoverable: exiting now\ndpkg-deb: error: tar subprocess returned error exit status 2\ndpkg-scanpackages: error: couldn't parse control information from ./ncr-upstart_0.0.3-hypernode20200320.130813_amd64.deb", "stderr_lines": ["tar: Archive is compressed. Use -J option", "tar: Error is not recoverable: exiting now", "dpkg-deb: error: tar subprocess returned error exit status 2", "dpkg-scanpackages: error: couldn't parse control information from ./ncr-upstart_0.0.3-hypernode20200320.130813_amd64.deb"], "stdout": "", "stdout_lines": []}
```